### PR TITLE
Fix auction_worker_defaults.json template

### DIFF
--- a/profiles/templates/auction_worker_defaults.json
+++ b/profiles/templates/auction_worker_defaults.json
@@ -20,7 +20,7 @@
   "sentinel_cluster_name": "{{sentinel_cluster_name}}",
   "planning_procerude": "{{planning_procerude}}",
   "sandbox_mode": "{{sandbox_mode}}",
-  "with_document_service": {{ with_document_service |default('false') }},
+  "with_document_service": {{ with_document_service|default('false', true) }},
   "DOCUMENT_SERVICE": {
     "url": "{{ document_service_url| default('') }}",
     "username": "{{ document_service_username| default('') }}",


### PR DESCRIPTION
Without this option we get invalid json with key/value pair "with_document_service": ,
instead of "with_document_service": false
See 'default' filter in Jinjia documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.auction.buildout/3)
<!-- Reviewable:end -->
