### PR TITLE
Add unified timestamps to the logs

### DIFF
--- a/profiles/base.cfg
+++ b/profiles/base.cfg
@@ -91,6 +91,7 @@ pubsub_endpoint = ipc://${buildout:directory}/var/circus_pubsub
 stats_endpoint = ipc://${buildout:directory}/var/circus_stats
 auctions_server_port = ${ports:1}
 auth_server_port = ${ports:3}
+logging_time_format = %Y-%m-%d %H:%M:%S
 
 [couchdb.ini]
 <= config-from-template

--- a/profiles/templates/circus.ini
+++ b/profiles/templates/circus.ini
@@ -17,10 +17,12 @@ cmd = couchdb
 args = -a {{ parts.buildout.directory }}/etc/couchdb.ini
 stdout_stream.class = FileStream
 stdout_stream.filename = {{ parts.buildout.directory }}/var/log/couchdb.stdout.log
+stdout_stream.time_format = {{ logging_time_format }}
 stdout_stream.max_bytes = 134217728
 stdout_stream.backup_count = 1
 stderr_stream.class = FileStream
 stderr_stream.filename = {{ parts.buildout.directory }}/var/log/couchdb.stderr.log
+stderr_stream.time_format = {{ logging_time_format }}
 stderr_stream.max_bytes = 134217728
 stderr_stream.backup_count = 1
 
@@ -36,10 +38,12 @@ copy_env = True
 copy_path = True
 stdout_stream.class = FileStream
 stdout_stream.filename = {{ parts.buildout.directory }}/var/log/redis.stdout.log
+stdout_stream.time_format = {{ logging_time_format }}
 stdout_stream.max_bytes = 134217728
 stdout_stream.backup_count = 1
 stderr_stream.class = FileStream
 stderr_stream.filename = {{ parts.buildout.directory }}/var/log/redis.stderr.log
+stderr_stream.time_format = {{ logging_time_format }}
 stderr_stream.max_bytes = 134217728
 stderr_stream.backup_count = 1
 
@@ -55,10 +59,12 @@ copy_env = True
 copy_path = True
 stdout_stream.class = FileStream
 stdout_stream.filename = {{ parts.buildout.directory }}/var/log/sentinel.stdout.log
+stdout_stream.time_format = {{ logging_time_format }}
 stdout_stream.max_bytes = 134217728
 stdout_stream.backup_count = 1
 stderr_stream.class = FileStream
 stderr_stream.filename = {{ parts.buildout.directory }}/var/log/sentinel.stderr.log
+stderr_stream.time_format = {{ logging_time_format }}
 stderr_stream.max_bytes = 134217728
 stderr_stream.backup_count = 1
 
@@ -71,10 +77,12 @@ PATH = /usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:$PATH
 cmd = {{ parts.buildout.directory }}/bin/gunicorn --paste {{ parts.buildout.directory }}/etc/auctions.ini --access-logfile - --error-log - --statsd-host=localhost:8125 --statsd-prefix auctions_server
 stdout_stream.class = FileStream
 stdout_stream.filename = {{ parts.buildout.directory }}/var/log/auctions.stdout.log
+stdout_stream.time_format = {{ logging_time_format }}
 stdout_stream.max_bytes = 134217728
 stdout_stream.backup_count = 1
 stderr_stream.class = FileStream
 stderr_stream.filename = {{ parts.buildout.directory }}/var/log/auctions.stderr.log
+stderr_stream.time_format = {{ logging_time_format }}
 stderr_stream.max_bytes = 134217728
 stderr_stream.backup_count = 1
 
@@ -85,10 +93,12 @@ stderr_stream.backup_count = 1
 cmd = {{ parts.buildout.directory }}/bin/gunicorn --paste {{ parts.buildout.directory }}/etc/oauth_provider.ini --access-logfile - --error-log - --statsd-host=localhost:8125 --statsd-prefix oauth_server
 stdout_stream.class = FileStream
 stdout_stream.filename = {{ parts.buildout.directory }}/var/log/oauth.stdout.log
+stdout_stream.time_format = {{ logging_time_format }}
 stdout_stream.max_bytes = 134217728
 stdout_stream.backup_count = 1
 stderr_stream.class = FileStream
 stderr_stream.filename = {{ parts.buildout.directory }}/var/log/oauth.stderr.log
+stderr_stream.time_format = {{ logging_time_format }}
 stderr_stream.max_bytes = 134217728
 stderr_stream.backup_count = 1
 
@@ -104,10 +114,12 @@ shell = True
 copy_env = True
 stdout_stream.class = FileStream
 stdout_stream.filename = {{ parts.buildout.directory }}/var/log/data_bridge.stdout.log
+stdout_stream.time_format = {{ logging_time_format }}
 stdout_stream.max_bytes = 134217728
 stdout_stream.backup_count = 1
 stderr_stream.class = FileStream
 stderr_stream.filename = {{ parts.buildout.directory }}/var/log/data_bridge.stderr.log
+stderr_stream.time_format = {{ logging_time_format }}
 stderr_stream.max_bytes = 134217728
 stderr_stream.backup_count = 1
 {% endif %}
@@ -121,10 +133,12 @@ shell = True
 copy_env = True
 stdout_stream.class = FileStream
 stdout_stream.filename = {{ parts.buildout.directory }}/var/log/penstock.stdout.log
+stdout_stream.time_format = {{ logging_time_format }}
 stdout_stream.max_bytes = 134217728
 stdout_stream.backup_count = 1
 stderr_stream.class = FileStream
 stderr_stream.filename = {{ parts.buildout.directory }}/var/log/penstock.stderr.log
+stderr_stream.time_format = {{ logging_time_format }}
 stderr_stream.max_bytes = 134217728
 stderr_stream.backup_count = 1
 {% endif %}
@@ -139,10 +153,12 @@ singleton = True
 respawn = False
 stdout_stream.class = FileStream
 stdout_stream.filename = {{ parts.buildout.directory }}/var/log/auctions_chronograph.stdout.log
+stdout_stream.time_format = {{ logging_time_format }}
 stdout_stream.max_bytes = 134217728
 stdout_stream.backup_count = 1
 stderr_stream.class = FileStream
 stderr_stream.filename = {{ parts.buildout.directory }}/var/log/auctions_chronograph.stderr.log
+stderr_stream.time_format = {{ logging_time_format }}
 stderr_stream.max_bytes = 134217728
 stderr_stream.backup_count = 1
 {% endif %}
@@ -153,10 +169,12 @@ cmd = /usr/bin/openresty
 args = -c {{ parts.buildout.directory }}/etc/nginx.conf -p {{ parts.buildout.directory }}
 stdout_stream.class = FileStream
 stdout_stream.filename = {{ parts.buildout.directory }}/var/log/nginx.stdout.log
+stdout_stream.time_format = {{ logging_time_format }}
 stdout_stream.max_bytes = 134217728
 stdout_stream.backup_count = 1
 stderr_stream.class = FileStream
 stderr_stream.filename = {{ parts.buildout.directory }}/var/log/nginx.stderr.log
+stderr_stream.time_format = {{ logging_time_format }}
 stderr_stream.max_bytes = 134217728
 stderr_stream.backup_count = 1
 {% endif %}


### PR DESCRIPTION
Circus captures stdouts and stderrs of managed processes,
so we must specify how to treat with those streams.

Before this commit circus simply wrote the streams to the
apropriate files, so format and presence of timestamps were left
to supervised processes.

This commit will set unified timestamp prefix on applications
streams.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.auction.buildout/34)
<!-- Reviewable:end -->
